### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-  "name" : "grunt-handlebars-simple-layouts",
-  "description" : "Handlebars task to render Handlebars templates to HTML",
-  "version" : "0.2.4",
-  "homepage" : "https://github.com/yong1236/grunt-handlebars-simple-layouts",
-  "author" : {
-    "name" : "Thierry Charbonnel",
-    "email" : "info@autreplanete.com",
-    "url" : "http://www.autreplanete.com"
+  "name": "grunt-handlebars-simple-layouts",
+  "description": "Handlebars task to render Handlebars templates to HTML",
+  "version": "0.2.4",
+  "homepage": "https://github.com/yong1236/grunt-handlebars-simple-layouts",
+  "author": {
+    "name": "Thierry Charbonnel",
+    "email": "info@autreplanete.com",
+    "url": "http://www.autreplanete.com"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "git://github.com/yong1236/grunt-handlebars-simple-layouts.git"
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yong1236/grunt-handlebars-simple-layouts.git"
   },
-  "bugs" : {
-    "url" : "https://github.com/yong1236/grunt-handlebars-simple-layouts/issues"
+  "bugs": {
+    "url": "https://github.com/yong1236/grunt-handlebars-simple-layouts/issues"
   },
-  "main" : "Gruntfile.js",
-  "bin" : "bin/grunt-handlebars-simple-layouts",
-  "engines" : {
-    "node" : ">= 0.8.0"
+  "main": "Gruntfile.js",
+  "bin": "bin/grunt-handlebars-simple-layouts",
+  "engines": {
+    "node": ">= 0.8.0"
   },
-  "scripts" : {
-    "test" : "grunt test"
+  "scripts": {
+    "test": "grunt test"
   },
-  "dependencies" : {
+  "dependencies": {
     "async": "^1.4.0",
     "handlebars": "~3.0.3",
     "chalk": "^0.5.1",
@@ -31,7 +31,7 @@
     "resolve-dep": "~0.5.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",
@@ -42,6 +42,8 @@
     "handlebars-helper-moment": "*"
   },
   "keywords": [
-    "gruntplugin", "handlebars", "template"
+    "gruntplugin",
+    "handlebars",
+    "template"
   ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
